### PR TITLE
Fixup: module import missing dots

### DIFF
--- a/SRC/packetEssentials/lib/unifier.py
+++ b/SRC/packetEssentials/lib/unifier.py
@@ -1,6 +1,6 @@
 import subprocess, time
-from drivers import Drivers
-from chan_freq import ChanFreq
+from .drivers import Drivers
+from .chan_freq import ChanFreq
 from scapy.utils import hexstr
 
 ### Not sure if this is needed here


### PR DESCRIPTION
Hi, I installed packetEssentials using pip (packetEssentials==1.0.2) and when I imported the module I got:

```
In [1]: import packetEssentials                                                                                                                                                                                    
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-dfc088c7c082> in <module>
----> 1 import packetEssentials

~/.local/share/virtualenvs/XXX/lib/python3.5/site-packages/packetEssentials/__init__.py in <module>
      6 from .lib.nic import Tap
      7 from .lib.subtypes import Subtypes
----> 8 from .lib.unifier import Unify
      9 from .lib.utils import Poption
     10 

~/.local/share/virtualenvs/XXX/lib/python3.5/site-packages/packetEssentials/lib/unifier.py in <module>
      1 import subprocess, time
----> 2 from drivers import Drivers
      3 from chan_freq import ChanFreq
      4 from scapy.utils import hexstr
      5 

ImportError: No module named 'drivers'
```

I guess that drivers and chan_freq should be relative imports within module?

Best,
Maxime